### PR TITLE
feat: pbkdf2 support

### DIFF
--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -1,0 +1,3 @@
+// Package encoding provides custom encoding schemes which
+// differ from the standard base64 provided in the stdlib.
+package encoding

--- a/internal/encoding/pbkdf2.go
+++ b/internal/encoding/pbkdf2.go
@@ -1,0 +1,10 @@
+package encoding
+
+import "encoding/base64"
+
+const encodePbkdf2 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789./"
+
+// Pbkdf2B64 is an alternative base64 encoding used by pbkdf2.
+// Bassicaly it's `+` replaced by `.`.
+// https://passlib.readthedocs.io/en/stable/lib/passlib.utils.binary.html#passlib.utils.binary.ab64_encode
+var Pbkdf2B64 = base64.NewEncoding(encodePbkdf2).WithPadding(base64.NoPadding)

--- a/internal/testvalues/passlib_pbkdf2.py
+++ b/internal/testvalues/passlib_pbkdf2.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+from passlib.hash import pbkdf2_sha1, pbkdf2_sha256, pbkdf2_sha512
+
+
+password = "password"
+salt = bytes("randomsaltishard", 'utf-8')
+rounds = 12
+
+print("Pbkdf2Sha1Encoded", " = `", pbkdf2_sha1.hash(password, salt=salt, rounds=rounds), "`", sep="")
+print("Pbkdf2Sha256Encoded", " = `", pbkdf2_sha256.hash(password, salt=salt, rounds=rounds), "`", sep="")
+print("Pbkdf2Sha512Encoded", " = `", pbkdf2_sha512.hash(password, salt=salt, rounds=rounds), "`", sep="")

--- a/internal/testvalues/pbkdf2.go
+++ b/internal/testvalues/pbkdf2.go
@@ -1,0 +1,20 @@
+package testvalues
+
+import "github.com/zitadel/passwap/internal/encoding"
+
+// pbkdf2 test values generated with passlib_pbkdf2.py
+const (
+	Pbkdf2Rounds        = 12
+	Pbkdf2Sha1KeyLen    = 20
+	Pbkdf2Sha256KeyLen  = 32
+	Pbkdf2Sha512KeyLen  = 64
+	Pbkdf2Sha1Encoded   = `$pbkdf2$12$cmFuZG9tc2FsdGlzaGFyZA$mwUqsMixIYMc/0eN4v1.l3SVDpk`
+	Pbkdf2Sha256Encoded = `$pbkdf2-sha256$12$cmFuZG9tc2FsdGlzaGFyZA$OFvEcLOIPFd/oq8egf10i.qJLI7A8nDjPLnolCWarQY`
+	Pbkdf2Sha512Encoded = `$pbkdf2-sha512$12$cmFuZG9tc2FsdGlzaGFyZA$e297piXvkpYxoYQAWD9zn1aKXCo3XmR91Xn9/WEGsHXU/7xaQzCV9upu4T5Jntq6AiZ6YX0diXnY7Ju5TEfUMA`
+)
+
+var (
+	Pbkdf2Sha1Hash   = parseBase64HashComponent(encoding.Pbkdf2B64, Pbkdf2Sha1Encoded, 4)
+	Pbkdf2Sha256Hash = parseBase64HashComponent(encoding.Pbkdf2B64, Pbkdf2Sha256Encoded, 4)
+	Pbkdf2Sha512Hash = parseBase64HashComponent(encoding.Pbkdf2B64, Pbkdf2Sha512Encoded, 4)
+)

--- a/internal/testvalues/scrypt.go
+++ b/internal/testvalues/scrypt.go
@@ -1,9 +1,6 @@
 package testvalues
 
-import (
-	"encoding/base64"
-	"strings"
-)
+import "encoding/base64"
 
 // Scrypt test values generated with scrypt.py
 const (
@@ -14,16 +11,5 @@ const (
 )
 
 var (
-	ScryptHash []byte
+	ScryptHash = parseBase64HashComponent(base64.RawStdEncoding, ScryptEncoded, 4)
 )
-
-func init() {
-	nodes := strings.Split(ScryptEncoded, "$")
-
-	var err error
-
-	ScryptHash, err = base64.RawStdEncoding.Strict().DecodeString(nodes[4])
-	if err != nil {
-		panic(err)
-	}
-}

--- a/internal/testvalues/values.go
+++ b/internal/testvalues/values.go
@@ -1,6 +1,7 @@
 package testvalues
 
 import (
+	"encoding/base64"
 	"io"
 	"strings"
 )
@@ -15,4 +16,13 @@ const (
 
 func SaltReader() io.Reader {
 	return strings.NewReader(Salt)
+}
+
+func parseBase64HashComponent(encoding *base64.Encoding, encoded string, pos int) []byte {
+	nodes := strings.Split(encoded, "$")
+	hash, err := encoding.Strict().DecodeString(nodes[pos])
+	if err != nil {
+		panic(err)
+	}
+	return hash
 }

--- a/pbkdf2/pbkdf2.go
+++ b/pbkdf2/pbkdf2.go
@@ -1,0 +1,231 @@
+// Package pbkdf2 provides salt generation, hashing and verification for x/crypto/pbkdf2.
+// RFC 8018 / PKCS #5 v2.1 specification allows use of all five FIPS Approved Hash Functions
+// SHA-1, SHA-224, SHA-256, SHA-384 and SHA-512 for HMAC.
+// All of the above are supported by the Verifier or through specific
+// constuctor functions of the Hasher.
+package pbkdf2
+
+import (
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/subtle"
+	"fmt"
+	"hash"
+	"io"
+	"strings"
+
+	"github.com/zitadel/passwap/internal/encoding"
+	"github.com/zitadel/passwap/internal/salt"
+	"github.com/zitadel/passwap/verifier"
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// Identifiers and prefixes that describe a
+// pbkdf2 encoded hash string.
+const (
+	IdentifierSHA1   = "pbkdf2"
+	IdentifierSHA224 = IdentifierSHA1 + "-sha224"
+	IdentifierSHA256 = IdentifierSHA1 + "-sha256"
+	IdentifierSHA384 = IdentifierSHA1 + "-sha384"
+	IdentifierSHA512 = IdentifierSHA1 + "-sha512"
+
+	Prefix = "$" + IdentifierSHA1
+)
+
+func hashFuncForIdentifier(id string) func() hash.Hash {
+	switch id {
+	case IdentifierSHA1:
+		return sha1.New
+	case IdentifierSHA224:
+		return sha256.New224
+	case IdentifierSHA256:
+		return sha256.New
+	case IdentifierSHA384:
+		return sha512.New384
+	case IdentifierSHA512:
+		return sha512.New
+	default:
+		return nil
+	}
+}
+
+// Params are used for all hasher modes.
+type Params struct {
+	Rounds  uint32
+	KeyLen  uint32
+	SaltLen uint32
+
+	id string
+}
+
+// Recommended parameters are based on passlib's defaults.
+var (
+	RecommendedSHA1Params = Params{
+		Rounds:  290000,
+		KeyLen:  20,
+		SaltLen: 16,
+	}
+	RecommendedSHA256Params = Params{
+		Rounds:  290000,
+		KeyLen:  32,
+		SaltLen: 16,
+	}
+	RecommendedSHA512Params = Params{
+		Rounds:  290000,
+		KeyLen:  64,
+		SaltLen: 16,
+	}
+)
+
+// Format of the Modular Crypt Format, as used by passlib.
+// See https://passlib.readthedocs.io/en/stable/lib/passlib.hash.pbkdf2_digest.html#format-algorithm
+const Format = "$%s$%d$%s$%s"
+
+var scanFormat = strings.ReplaceAll(Format, "$", " ")
+
+type checker struct {
+	Params
+
+	hash []byte
+	salt []byte
+
+	hf func() hash.Hash
+}
+
+func parse(encoded string) (*checker, error) {
+	if !strings.HasPrefix(encoded, Prefix) {
+		return nil, nil
+	}
+
+	var (
+		salt string
+		hash string
+		c    checker
+	)
+
+	// scanning needs a space seperated string, instead of dollar signs.
+	encoded = strings.ReplaceAll(encoded, "$", " ")
+
+	_, err := fmt.Sscanf(encoded, scanFormat, &c.id, &c.Rounds, &salt, &hash)
+	if err != nil {
+		return nil, fmt.Errorf("pbkdf2 parse: %w", err)
+	}
+
+	if c.hf = hashFuncForIdentifier(c.id); c.hf == nil {
+		return nil, fmt.Errorf("pbkdf2: unknown hash identifier %s", c.id)
+	}
+
+	c.salt, err = encoding.Pbkdf2B64.Strict().DecodeString(salt)
+	if err != nil {
+		return nil, fmt.Errorf("pbkdf2 parse salt: %w", err)
+	}
+
+	c.hash, err = encoding.Pbkdf2B64.Strict().DecodeString(hash)
+	if err != nil {
+		return nil, fmt.Errorf("pbkdf2 parse hash: %w", err)
+	}
+
+	c.KeyLen = uint32(len(c.hash))
+	c.SaltLen = uint32(len(c.salt))
+
+	return &c, nil
+}
+
+func (c *checker) verify(pw string) verifier.Result {
+	hash := pbkdf2.Key([]byte(pw), c.salt, int(c.Rounds), int(c.KeyLen), c.hf)
+	res := subtle.ConstantTimeCompare(hash, c.hash)
+
+	return verifier.Result(res)
+}
+
+type Hasher struct {
+	p    Params
+	rand io.Reader
+	hf   func() hash.Hash
+}
+
+// Hash implements passwap.Hasher.
+func (h *Hasher) Hash(password string) (string, error) {
+	salt, err := salt.New(h.rand, h.p.SaltLen)
+	if err != nil {
+		return "", fmt.Errorf("pbkdf2: %w", err)
+	}
+
+	hash := pbkdf2.Key([]byte(password), salt, int(h.p.Rounds), int(h.p.KeyLen), h.hf)
+
+	return fmt.Sprintf(Format,
+		h.p.id, h.p.Rounds,
+		encoding.Pbkdf2B64.EncodeToString(salt),
+		encoding.Pbkdf2B64.EncodeToString(hash),
+	), nil
+}
+
+// Verify implements passwap.Verifier
+func (h *Hasher) Verify(encoded, password string) (verifier.Result, error) {
+	c, err := parse(encoded)
+	if err != nil || c == nil {
+		return verifier.Skip, err
+	}
+
+	res := c.verify(password)
+	if res == 0 {
+		return verifier.Fail, nil
+	}
+
+	if h.p != c.Params {
+		return verifier.NeedUpdate, nil
+	}
+
+	return verifier.OK, nil
+}
+
+func newHasher(p Params, id string) *Hasher {
+	p.id = id
+	return &Hasher{
+		p:    p,
+		rand: rand.Reader,
+		hf:   hashFuncForIdentifier(id),
+	}
+}
+
+// NewSHA1 returns a pbkdf2 SHA1 Hasher.
+func NewSHA1(p Params) *Hasher {
+	return newHasher(p, IdentifierSHA1)
+}
+
+// NewSHA224 returns a pbkdf2 SHA224 Hasher.
+func NewSHA224(p Params) *Hasher {
+	return newHasher(p, IdentifierSHA224)
+}
+
+// NewSHA256 returns a pbkdf2 SHA256 Hasher.
+func NewSHA256(p Params) *Hasher {
+	return newHasher(p, IdentifierSHA256)
+}
+
+// NewSHA384 returns a pbkdf2 SHA384 Hasher.
+func NewSHA384(p Params) *Hasher {
+	return newHasher(p, IdentifierSHA384)
+}
+
+// NewSHA512 returns a pbkdf2 SHA512 Hasher.
+func NewSHA512(p Params) *Hasher {
+	return newHasher(p, IdentifierSHA512)
+}
+
+// Verify parses encoded and uses its pbkdf2 parameters
+// to verify password against its hash.
+// The HMAC message authentication scheme is taken from the encoded string.
+// Currently SHA-1, SHA-224, SHA-256, SHA-384 and SHA-512 are suppored.
+func Verify(encoded, password string) (verifier.Result, error) {
+	c, err := parse(encoded)
+	if err != nil || c == nil {
+		return verifier.Skip, err
+	}
+
+	return c.verify(password), nil
+}
+
+var Verifier = verifier.VerifyFunc(Verify)

--- a/pbkdf2/pbkdf2.go
+++ b/pbkdf2/pbkdf2.go
@@ -64,17 +64,27 @@ type Params struct {
 var (
 	RecommendedSHA1Params = Params{
 		Rounds:  290000,
-		KeyLen:  20,
+		KeyLen:  sha1.Size,
+		SaltLen: 16,
+	}
+	RecommendedSHA224Params = Params{
+		Rounds:  290000,
+		KeyLen:  sha256.Size224,
 		SaltLen: 16,
 	}
 	RecommendedSHA256Params = Params{
 		Rounds:  290000,
-		KeyLen:  32,
+		KeyLen:  sha256.Size,
+		SaltLen: 16,
+	}
+	RecommendedSHA384Params = Params{
+		Rounds:  290000,
+		KeyLen:  sha512.Size384,
 		SaltLen: 16,
 	}
 	RecommendedSHA512Params = Params{
 		Rounds:  290000,
-		KeyLen:  64,
+		KeyLen:  sha512.Size,
 		SaltLen: 16,
 	}
 )

--- a/pbkdf2/pbkdf2_test.go
+++ b/pbkdf2/pbkdf2_test.go
@@ -1,0 +1,493 @@
+package pbkdf2
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"hash"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/zitadel/passwap/internal/salt"
+	tv "github.com/zitadel/passwap/internal/testvalues"
+	"github.com/zitadel/passwap/verifier"
+)
+
+var (
+	testParamsSha1 = Params{
+		Rounds:  tv.Pbkdf2Rounds,
+		SaltLen: tv.SaltLen,
+		KeyLen:  tv.Pbkdf2Sha1KeyLen,
+		id:      IdentifierSHA1,
+	}
+	testParamsSha256 = Params{
+		Rounds:  tv.Pbkdf2Rounds,
+		SaltLen: tv.SaltLen,
+		KeyLen:  tv.Pbkdf2Sha256KeyLen,
+		id:      IdentifierSHA256,
+	}
+	testParamsSha512 = Params{
+		Rounds:  tv.Pbkdf2Rounds,
+		SaltLen: tv.SaltLen,
+		KeyLen:  tv.Pbkdf2Sha512KeyLen,
+		id:      IdentifierSHA512,
+	}
+)
+
+func Test_hashFuncForIdentifier(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want func() hash.Hash
+	}{
+		{
+			name: "empty arg",
+			id:   "",
+			want: nil,
+		},
+		{
+			name: "wrong arg",
+			id:   "foo",
+			want: nil,
+		},
+		{
+			name: IdentifierSHA1,
+			id:   IdentifierSHA1,
+			want: sha1.New,
+		},
+		{
+			name: IdentifierSHA224,
+			id:   IdentifierSHA224,
+			want: sha256.New224,
+		},
+		{
+			name: IdentifierSHA256,
+			id:   IdentifierSHA256,
+			want: sha256.New,
+		},
+		{
+			name: IdentifierSHA384,
+			id:   IdentifierSHA384,
+			want: sha512.New384,
+		},
+		{
+			name: IdentifierSHA512,
+			id:   IdentifierSHA512,
+			want: sha512.New,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hashFuncForIdentifier(tt.id)
+			if tt.want == nil {
+				if got != nil {
+					t.Error("hashFuncForIdentifier() not nil")
+				}
+				return
+			}
+			if !reflect.DeepEqual(got(), tt.want()) {
+				t.Errorf("hashFuncForIdentifier() = %v, want %v", got(), tt.want())
+			}
+		})
+	}
+}
+
+func Test_parse(t *testing.T) {
+	tests := []struct {
+		name    string
+		encoded string
+		want    *checker
+		wantErr bool
+	}{
+		{
+			name:    "success sha1",
+			encoded: tv.Pbkdf2Sha1Encoded,
+			want: &checker{
+				Params: testParamsSha1,
+				hash:   tv.Pbkdf2Sha1Hash,
+				salt:   []byte(tv.Salt),
+				hf:     sha1.New,
+			},
+		},
+		{
+			name:    "success sha256",
+			encoded: tv.Pbkdf2Sha256Encoded,
+			want: &checker{
+				Params: testParamsSha256,
+				hash:   tv.Pbkdf2Sha256Hash,
+				salt:   []byte(tv.Salt),
+				hf:     sha256.New,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "success sha512",
+			encoded: tv.Pbkdf2Sha512Encoded,
+			want: &checker{
+				Params: testParamsSha512,
+				hash:   tv.Pbkdf2Sha512Hash,
+				salt:   []byte(tv.Salt),
+				hf:     sha512.New,
+			},
+			wantErr: false,
+		},
+		/*
+			SHA-224 and SHA-384 are not implemented in passlib,
+			therefore there are no encoded strings to compare with.
+			We will only test encode-and-verify cases instead.
+		*/
+		{
+			name:    "wrong prefix",
+			encoded: tv.Argon2iEncoded,
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "scan error",
+			encoded: Prefix + "!!!!",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "unknow hash identifier",
+			encoded: strings.ReplaceAll(tv.Pbkdf2Sha256Encoded, "sha256", "sha123"),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "salt decode error",
+			encoded: `$pbkdf2$12$~~$mwUqsMixIYMc/0eN4v1.l3SVDpk`,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "hash decode error",
+			encoded: `$pbkdf2$12$cmFuZG9tc2FsdGlzaGFyZA$~~`,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parse(tt.encoded)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.want != nil {
+				if !reflect.DeepEqual(got.Params, tt.want.Params) {
+					t.Errorf("parse() Params =\n%v\nwant\n%v", got.Params, tt.want.Params)
+				}
+				if !bytes.Equal(got.hash, tt.want.hash) {
+					t.Errorf("parse() hash =\n%v\nwant\n%v", got.hash, tt.want.hash)
+				}
+				if !bytes.Equal(got.salt, tt.want.salt) {
+					t.Errorf("parse() salt =\n%v\nwant\n%v", got.salt, tt.want.salt)
+				}
+				if !reflect.DeepEqual(got.hf(), tt.want.hf()) {
+					t.Errorf("parse() hf =\n%v\nwant\n%v", got.hf(), tt.want.hf())
+				}
+			} else if got != nil {
+				t.Errorf("parse() =\n%v\nwant\n%v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasher_Hash(t *testing.T) {
+	tests := []struct {
+		name    string
+		h       Hasher
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "salt error",
+			h: Hasher{
+				p:    testParamsSha1,
+				rand: salt.ErrReader{},
+				hf:   sha1.New,
+			},
+			wantErr: true,
+		},
+		{
+			name: "sha1",
+			h: Hasher{
+				p:    testParamsSha1,
+				rand: strings.NewReader(tv.Salt),
+				hf:   sha1.New,
+			},
+			want: tv.Pbkdf2Sha1Encoded,
+		},
+		{
+			name: "sha256",
+			h: Hasher{
+				p:    testParamsSha256,
+				rand: strings.NewReader(tv.Salt),
+				hf:   sha256.New,
+			},
+			want: tv.Pbkdf2Sha256Encoded,
+		},
+		{
+			name: "sha512",
+			h: Hasher{
+				p:    testParamsSha512,
+				rand: strings.NewReader(tv.Salt),
+				hf:   sha512.New,
+			},
+			want: tv.Pbkdf2Sha512Encoded,
+		},
+		/*
+			SHA-224 and SHA-384 are not implemented in passlib,
+			therefore there are no encoded strings to compare with.
+			We will only test encode-and-verify cases instead.
+		*/
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.h.Hash(tv.Password)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Hasher.Hash() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Hasher.Hash() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasher_Verify(t *testing.T) {
+	type args struct {
+		encoded  string
+		password string
+	}
+	tests := []struct {
+		name    string
+		h       Hasher
+		args    args
+		want    verifier.Result
+		wantErr bool
+	}{
+		{
+			name: "parse error",
+			h: Hasher{
+				p: testParamsSha1,
+			},
+			args: args{
+				Prefix + "!!!",
+				tv.Password,
+			},
+			want:    verifier.Skip,
+			wantErr: true,
+		},
+		{
+			name: "sha1, wrong password",
+			h: Hasher{
+				p: testParamsSha1,
+			},
+			args: args{
+				tv.Pbkdf2Sha1Encoded,
+				"wrong",
+			},
+			want: verifier.Fail,
+		},
+		{
+			name: "sha256, wrong password",
+			h: Hasher{
+				p: testParamsSha256,
+			},
+			args: args{
+				tv.Pbkdf2Sha256Encoded,
+				"wrong",
+			},
+			want: verifier.Fail,
+		},
+		{
+			name: "sha512, wrong password",
+			h: Hasher{
+				p: testParamsSha512,
+			},
+			args: args{
+				tv.Pbkdf2Sha512Encoded,
+				"wrong",
+			},
+			want: verifier.Fail,
+		},
+		{
+			name: "sha1, ok",
+			h: Hasher{
+				p: testParamsSha1,
+			},
+			args: args{
+				tv.Pbkdf2Sha1Encoded,
+				tv.Password,
+			},
+			want: verifier.OK,
+		},
+		{
+			name: "sha256, ok",
+			h: Hasher{
+				p: testParamsSha256,
+			},
+			args: args{
+				tv.Pbkdf2Sha256Encoded,
+				tv.Password,
+			},
+			want: verifier.OK,
+		},
+		{
+			name: "sha512, ok",
+			h: Hasher{
+				p: testParamsSha512,
+			},
+			args: args{
+				tv.Pbkdf2Sha512Encoded,
+				tv.Password,
+			},
+			want: verifier.OK,
+		},
+		{
+			name: "hasher update",
+			h: Hasher{
+				p: testParamsSha512,
+			},
+			args: args{
+				tv.Pbkdf2Sha1Encoded,
+				tv.Password,
+			},
+			want: verifier.NeedUpdate,
+		},
+		{
+			name: "rounds update",
+			h: Hasher{
+				p: Params{
+					Rounds:  tv.Pbkdf2Rounds + 1,
+					SaltLen: tv.SaltLen,
+					KeyLen:  tv.Pbkdf2Sha512KeyLen,
+					id:      IdentifierSHA512,
+				},
+			},
+			args: args{
+				tv.Pbkdf2Sha512Encoded,
+				tv.Password,
+			},
+			want: verifier.NeedUpdate,
+		},
+		{
+			name: "KeyLen update",
+			h: Hasher{
+				p: Params{
+					Rounds:  tv.Pbkdf2Rounds,
+					SaltLen: tv.SaltLen,
+					KeyLen:  tv.Pbkdf2Sha512KeyLen + 1,
+					id:      IdentifierSHA512,
+				},
+			},
+			args: args{
+				tv.Pbkdf2Sha512Encoded,
+				tv.Password,
+			},
+			want: verifier.NeedUpdate,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.h.Verify(tt.args.encoded, tt.args.password)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Hasher.Verify() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Hasher.Verify() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasher(t *testing.T) {
+	params := Params{
+		Rounds:  tv.Pbkdf2Rounds,
+		SaltLen: tv.SaltLen,
+		KeyLen:  tv.Pbkdf2Sha512KeyLen,
+	}
+	tests := [...]*Hasher{
+		NewSHA1(params),
+		NewSHA224(params),
+		NewSHA256(params),
+		NewSHA384(params),
+		NewSHA512(params),
+	}
+	for _, h := range tests {
+		t.Run(h.p.id, func(t *testing.T) {
+			hash, err := h.Hash(tv.Password)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Log(hash)
+			if !strings.Contains(hash, h.p.id) {
+				t.Errorf("Hasher.Hash() = %s, does not contain %s", hash, h.p.id)
+			}
+			res, err := h.Verify(hash, tv.Password)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if res != verifier.OK {
+				t.Errorf("Hasher.Verify() = %s, want %s", res, verifier.OK)
+			}
+		})
+	}
+}
+
+func TestVerify(t *testing.T) {
+	type args struct {
+		encoded  string
+		password string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    verifier.Result
+		wantErr bool
+	}{
+		{
+			name: "parse error",
+			args: args{
+				Prefix + "!!!",
+				tv.Password,
+			},
+			want:    verifier.Skip,
+			wantErr: true,
+		},
+		{
+			name: "sha1, wrong password",
+			args: args{
+				tv.Pbkdf2Sha1Encoded,
+				"wrong",
+			},
+			want: verifier.Fail,
+		},
+		{
+			name: "sha256, ok",
+			args: args{
+				tv.Pbkdf2Sha256Encoded,
+				tv.Password,
+			},
+			want: verifier.OK,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Verify(tt.args.encoded, tt.args.password)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Verify() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Verify() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add pbkdf2 support with all available Hash functions as documented in https://pkg.go.dev/golang.org/x/crypto/pbkdf2#pkg-overview

Closes #1