### PR TITLE
feat(pbkdf2): allow standard and padded encoding

### DIFF
--- a/internal/encoding/pbkdf2.go
+++ b/internal/encoding/pbkdf2.go
@@ -1,6 +1,9 @@
 package encoding
 
-import "encoding/base64"
+import (
+	"encoding/base64"
+	"strings"
+)
 
 const encodePbkdf2 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789./"
 
@@ -8,3 +11,14 @@ const encodePbkdf2 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012345
 // Bassicaly it's `+` replaced by `.`.
 // https://passlib.readthedocs.io/en/stable/lib/passlib.utils.binary.html#passlib.utils.binary.ab64_encode
 var Pbkdf2B64 = base64.NewEncoding(encodePbkdf2).WithPadding(base64.NoPadding)
+
+// AutoDecodePbkdf2 decodes a base64 encoded string in the
+// Pbkdf alternative format or [base64.RawStdEncoding].
+// Any padding is removed from the encoded string
+func AutoDecodePbkdf2(encoded string) ([]byte, error) {
+	encoding := Pbkdf2B64
+	if strings.ContainsRune(encoded, '+') {
+		encoding = base64.RawStdEncoding
+	}
+	return encoding.DecodeString(strings.TrimRight(encoded, "="))
+}

--- a/internal/encoding/pbkdf2_test.go
+++ b/internal/encoding/pbkdf2_test.go
@@ -1,0 +1,71 @@
+package encoding
+
+import (
+	"encoding/base64"
+	"reflect"
+	"testing"
+)
+
+func TestAutoDecodePbkdf2(t *testing.T) {
+	in := []byte{255, 255, 255, 254, 254, 254, 253, 253, 253, 250}
+
+	type args struct {
+		encoded string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "Standard, no padding",
+			args: args{
+				encoded: base64.RawStdEncoding.EncodeToString(in),
+			},
+			want: in,
+		},
+		{
+			name: "Standard, padding",
+			args: args{
+				encoded: base64.StdEncoding.EncodeToString(in),
+			},
+			want: in,
+		},
+		{
+			name: "pbkdf2, no padding",
+			args: args{
+				encoded: Pbkdf2B64.EncodeToString(in),
+			},
+			want: in,
+		},
+		{
+			name: "pbkdf2, padding",
+			args: args{
+				encoded: Pbkdf2B64.WithPadding(base64.StdPadding).EncodeToString(in),
+			},
+			want: in,
+		},
+		{
+			name: "decode erorr",
+			args: args{
+				encoded: "~~~",
+			},
+			want:    []byte{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log(tt.args.encoded)
+			got, err := AutoDecodePbkdf2(tt.args.encoded)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AutoDecodePbkdf2() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AutoDecodePbkdf2() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/testvalues/pbkdf2.go
+++ b/internal/testvalues/pbkdf2.go
@@ -1,6 +1,8 @@
 package testvalues
 
-import "github.com/zitadel/passwap/internal/encoding"
+import (
+	"github.com/zitadel/passwap/internal/encoding"
+)
 
 // pbkdf2 test values generated with passlib_pbkdf2.py
 const (
@@ -11,6 +13,12 @@ const (
 	Pbkdf2Sha1Encoded   = `$pbkdf2$12$cmFuZG9tc2FsdGlzaGFyZA$mwUqsMixIYMc/0eN4v1.l3SVDpk`
 	Pbkdf2Sha256Encoded = `$pbkdf2-sha256$12$cmFuZG9tc2FsdGlzaGFyZA$OFvEcLOIPFd/oq8egf10i.qJLI7A8nDjPLnolCWarQY`
 	Pbkdf2Sha512Encoded = `$pbkdf2-sha512$12$cmFuZG9tc2FsdGlzaGFyZA$e297piXvkpYxoYQAWD9zn1aKXCo3XmR91Xn9/WEGsHXU/7xaQzCV9upu4T5Jntq6AiZ6YX0diXnY7Ju5TEfUMA`
+)
+
+// manually created to test decoding of standard encoding with padding
+const (
+	Pbkdf2Sha256StdEncoded        = `$pbkdf2-sha256$12$cmFuZG9tc2FsdGlzaGFyZA$OFvEcLOIPFd/oq8egf10i+qJLI7A8nDjPLnolCWarQY`
+	Pbkdf2Sha256StdEncodedPadding = `$pbkdf2-sha256$12$cmFuZG9tc2FsdGlzaGFyZA==$OFvEcLOIPFd/oq8egf10i+qJLI7A8nDjPLnolCWarQY=`
 )
 
 var (

--- a/pbkdf2/pbkdf2_test.go
+++ b/pbkdf2/pbkdf2_test.go
@@ -133,6 +133,28 @@ func Test_parse(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:    "success std encoding",
+			encoded: tv.Pbkdf2Sha256StdEncoded,
+			want: &checker{
+				Params: testParamsSha256,
+				hash:   tv.Pbkdf2Sha256Hash,
+				salt:   []byte(tv.Salt),
+				hf:     sha256.New,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "success std encoding with padding",
+			encoded: tv.Pbkdf2Sha256StdEncodedPadding,
+			want: &checker{
+				Params: testParamsSha256,
+				hash:   tv.Pbkdf2Sha256Hash,
+				salt:   []byte(tv.Salt),
+				hf:     sha256.New,
+			},
+			wantErr: false,
+		},
 		/*
 			SHA-224 and SHA-384 are not implemented in passlib,
 			therefore there are no encoded strings to compare with.


### PR DESCRIPTION
We found that there are people that need to verify passwords imported form sources that use standard base64 encoding for pbkdf2, instead of the alternative encoding defined by passlib. This change allows verifying standard base64 by "guessing based  on  a `+` or `.` symbol being present in the encoded string. These symbols are the only difference between standard and pbkdf2 alternatice encoding.
Paddings are always removed so that we can always use the encodings without padding.