### PR TITLE
chore(deps): add go 1.22 support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.18', '1.19', '1.20', '1.21']
+        go: ['1.20', '1.21', '1.22']
     steps:
     - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -270,11 +270,10 @@ Versions that also build are marked with :warning:.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| <1.18   | :x:                |
-| 1.18    | :warning:          |
-| 1.19    | :warning:          |
-| 1.20    | :white_check_mark: |
+| <1.20   | :x:                |
+| 1.20    | :warning:          |
 | 1.21    | :white_check_mark: |
+| 1.22    | :white_check_mark: |
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zitadel/passwap
 
-go 1.18
+go 1.20
 
 require golang.org/x/crypto v0.24.0
 


### PR DESCRIPTION
This change add support for go 1.22.
Support for Go version older than 1.20 is dropped.