### PR TITLE
chore(test): verify padded encoding

### DIFF
--- a/pbkdf2/pbkdf2_test.go
+++ b/pbkdf2/pbkdf2_test.go
@@ -361,6 +361,17 @@ func TestHasher_Verify(t *testing.T) {
 			want: verifier.OK,
 		},
 		{
+			name: "sha256, padded, ok",
+			h: Hasher{
+				p: testParamsSha256,
+			},
+			args: args{
+				tv.Pbkdf2Sha256StdEncodedPadding,
+				tv.Password,
+			},
+			want: verifier.OK,
+		},
+		{
 			name: "sha512, ok",
 			h: Hasher{
 				p: testParamsSha512,
@@ -495,6 +506,14 @@ func TestVerify(t *testing.T) {
 			name: "sha256, ok",
 			args: args{
 				tv.Pbkdf2Sha256Encoded,
+				tv.Password,
+			},
+			want: verifier.OK,
+		},
+		{
+			name: "sha256, padded, ok",
+			args: args{
+				tv.Pbkdf2Sha256StdEncodedPadding,
 				tv.Password,
 			},
 			want: verifier.OK,


### PR DESCRIPTION
Add a test that does the full verification of a base64 with padding encoded PBKDF2 hash string.

Related to https://github.com/zitadel/zitadel/issues/8491