### PR TITLE
chore(deps): upgrade go to v1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.20', '1.21', '1.22']
+        go: ['1.20', '1.21', '1.22', '1.23']
     steps:
     - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -284,8 +284,9 @@ Versions that also build are marked with :warning:.
 | ------- | ------------------ |
 | <1.20   | :x:                |
 | 1.20    | :warning:          |
-| 1.21    | :white_check_mark: |
+| 1.21    | :warning:          |
 | 1.22    | :white_check_mark: |
+| 1.23    | :white_check_mark: |
 
 ## License
 


### PR DESCRIPTION
Add Go 1.23 to the build matrix and readme.

Related to zitadel/zitadel#8906