### PR TITLE
feat: verifier for MD5 salted passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,21 +28,23 @@ needs to be updated.
 
 ### Algorithms
 
-| Algorithm      | Identifiers                                                        | Secure             |
-| -------------- | ------------------------------------------------------------------ | ------------------ |
-| [argon2][1]    | argon2i, argon2id                                                  | :heavy_check_mark: |
-| [bcrypt][2]    | 2, 2a, 2b, 2y                                                      | :heavy_check_mark: |
-| [md5-crypt][3] | 1                                                                  | :x:                |
-| [md5 plain][4] | Hex encoded string                                                 | :x:                |
-| [scrypt][5]    | scrypt, 7                                                          | :heavy_check_mark: |
-| [pbkpdf2][6]   | pbkdf2, pbkdf2-sha224, pbkdf2-sha256, pbkdf2-sha384, pbkdf2-sha512 | :heavy_check_mark: |
+| Algorithm       | Identifiers                                                        | Secure             |
+|-----------------|--------------------------------------------------------------------| ------------------ |
+| [argon2][1]     | argon2i, argon2id                                                  | :heavy_check_mark: |
+| [bcrypt][2]     | 2, 2a, 2b, 2y                                                      | :heavy_check_mark: |
+| [md5-crypt][3]  | 1                                                                  | :x:                |
+| [md5 plain][4]  | Hex encoded string                                                 | :x:                |
+| [md5 salted][5] | md5salted-suffix,md5salted-prefix                                  | :x:                |
+| [scrypt][6]     | scrypt, 7                                                          | :heavy_check_mark: |
+| [pbkpdf2][7]    | pbkdf2, pbkdf2-sha224, pbkdf2-sha256, pbkdf2-sha384, pbkdf2-sha512 | :heavy_check_mark: |
 
 [1]: https://pkg.go.dev/github.com/zitadel/passwap/argon2
 [2]: https://pkg.go.dev/github.com/zitadel/passwap/bcrypt
 [3]: https://pkg.go.dev/github.com/zitadel/passwap/md5
 [4]: https://pkg.go.dev/github.com/zitadel/passwap/md5plain
-[5]: https://pkg.go.dev/github.com/zitadel/passwap/scrypt
-[6]: https://pkg.go.dev/github.com/zitadel/passwap/pbkdf2
+[5]: https://pkg.go.dev/github.com/zitadel/passwap/md5salted
+[6]: https://pkg.go.dev/github.com/zitadel/passwap/scrypt
+[7]: https://pkg.go.dev/github.com/zitadel/passwap/pbkdf2
 
 ### Encoding
 
@@ -120,6 +122,22 @@ For example passwap can verify passwords hashed by the following methods:
 
 MD5 is considered cryptographically broken and insecure. Also hashing without salt is a bad idea.
 Therefore passwap only supports verification to allow applications to migrate to better methods.
+
+### MD5 Salted
+
+MD5 Salted are base64 encode digest of password+salt (resp. salt+password)
+The resulting MD5salted Format string looks as follows:
+
+```
+$md5salted-suffix$kJ4QkJaQ$3EbD/pJddrq5HW3mpZ4KZ1
+(1)                  (2)          (3)
+```
+
+1. The identifier is md5salted-suffix or md5salted-prefix
+2. Salt string (will be added to password in exactly this form).
+3. Base64-like-encoded MD5 hash output of the password and salt combined (password+salt or salt+password).
+
+There is no cost parameter for MD5 because MD5 is old and is considered too light and insecure. It is provided to verify and migrate to a better algorithm. Do not use for new hashes.
 
 ### Scrypt
 

--- a/md5salted/md5salted.go
+++ b/md5salted/md5salted.go
@@ -1,0 +1,94 @@
+// Package md5salted provides hashing and verification of
+// md5 encoded passwords prefixed or suffixed with salt.
+//
+// Note that md5 is considered cryptographically broken
+// and should not be used for new applications.
+// This package is only provided for legacy applications
+// that wish to migrate away from md5 to newer hashing methods.
+package md5salted
+
+import (
+	"crypto/md5"
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/zitadel/passwap/verifier"
+)
+
+const (
+	Identifier         = "md5salted"
+	IdentifierSuffixed = Identifier + "-suffix"
+	IdentifierPrefixed = Identifier + "-prefix"
+	Prefix             = "$" + Identifier
+
+	Format = "$%s$%s$%s"
+)
+
+var scanFormat = strings.ReplaceAll(Format, "$", " ")
+
+type checker struct {
+	salt          string
+	hash          string
+	saltpasswfunc func(string) []byte
+}
+
+func (c *checker) setSaltPasswFunc(id string) {
+	switch id {
+	case IdentifierPrefixed:
+		c.saltpasswfunc = func(passw string) []byte {
+			return []byte(c.salt + passw)
+		}
+	case IdentifierSuffixed:
+		c.saltpasswfunc = func(passw string) []byte {
+			return []byte(passw + c.salt)
+		}
+	default:
+		c.saltpasswfunc = nil
+	}
+}
+
+func parse(encoded string) (*checker, error) {
+	if !strings.HasPrefix(encoded, Prefix) {
+		return nil, nil
+	}
+
+	// scanning needs a space separated string, instead of dollar signs.
+	encoded = strings.ReplaceAll(encoded, "$", " ")
+	var c checker
+	var id string
+	_, err := fmt.Sscanf(encoded, scanFormat, &id, &c.salt, &c.hash)
+	if err != nil {
+		return nil, fmt.Errorf("md5salted parse: %w", err)
+	}
+	c.setSaltPasswFunc(id)
+	if c.saltpasswfunc == nil {
+		return nil, fmt.Errorf("md5salted unknow identifier: %s", id)
+	}
+	return &c, nil
+}
+
+func (c *checker) verify(password string) (verifier.Result, error) {
+	checksum := md5.Sum(c.saltpasswfunc(password))
+	decoded, err := base64.StdEncoding.DecodeString(c.hash)
+	if err != nil {
+		return verifier.Skip, err
+	}
+
+	return verifier.Result(
+		subtle.ConstantTimeCompare(checksum[:], decoded),
+	), nil
+}
+
+// Verify parses encoded and verfies password against the checksum.
+func Verify(encoded, password string) (verifier.Result, error) {
+	c, err := parse(encoded)
+	if err != nil || c == nil {
+		return verifier.Skip, err
+	}
+
+	return c.verify(password)
+}
+
+var Verifier = verifier.VerifyFunc(Verify)

--- a/md5salted/md5salted.go
+++ b/md5salted/md5salted.go
@@ -81,7 +81,7 @@ func (c *checker) verify(password string) (verifier.Result, error) {
 	), nil
 }
 
-// Verify parses encoded and verfies password against the checksum.
+// Verify parses encoded and verifies password against the checksum.
 func Verify(encoded, password string) (verifier.Result, error) {
 	c, err := parse(encoded)
 	if err != nil || c == nil {

--- a/md5salted/md5salted.go
+++ b/md5salted/md5salted.go
@@ -64,7 +64,7 @@ func parse(encoded string) (*checker, error) {
 	}
 	c.setSaltPasswFunc(id)
 	if c.saltpasswfunc == nil {
-		return nil, fmt.Errorf("md5salted unknow identifier: %s", id)
+		return nil, fmt.Errorf("md5salted unknown identifier: %s", id)
 	}
 	return &c, nil
 }

--- a/md5salted/md5salted_test.go
+++ b/md5salted/md5salted_test.go
@@ -1,10 +1,10 @@
 package md5salted
 
 import (
-	"github.com/zitadel/passwap/internal/testvalues"
 	"reflect"
 	"testing"
 
+        "github.com/zitadel/passwap/internal/testvalues"
 	"github.com/zitadel/passwap/verifier"
 )
 

--- a/md5salted/md5salted_test.go
+++ b/md5salted/md5salted_test.go
@@ -1,0 +1,185 @@
+package md5salted
+
+import (
+	"github.com/zitadel/passwap/internal/testvalues"
+	"reflect"
+	"testing"
+
+	"github.com/zitadel/passwap/verifier"
+)
+
+const (
+	Password          = "Test1000!"
+	SaltEncoded       = "c2FsdA=="
+	MD5SaltedSHash    = "R58+SD/95ORa9VZ9BPS5FA=="
+	MD5SaltedPHash    = "0M2MYNUmNumHqqQ+kmuTUQ=="
+	MD5SaltedEncodedS = "$md5salted-suffix$c2FsdA==$R58+SD/95ORa9VZ9BPS5FA=="
+	MD5SaltedEncodedP = "$md5salted-prefix$c2FsdA==$0M2MYNUmNumHqqQ+kmuTUQ=="
+)
+
+func Test_parse(t *testing.T) {
+	type args struct {
+		encoded string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *checker
+		wantErr bool
+	}{
+		{
+			name: "not md5",
+			args: args{testvalues.EncodedBcrypt2b},
+		},
+		{
+			name: "not md5",
+			args: args{testvalues.MD5Encoded},
+		},
+		{
+			name:    "scan error",
+			args:    args{"$md5salted$foo"},
+			wantErr: true,
+		},
+		{
+			name:    "wrong identifier",
+			args:    args{"$md5salted-unknow$foo$foo"},
+			wantErr: true,
+		},
+		{
+			name: "success suffix",
+			args: args{MD5SaltedEncodedS},
+			want: &checker{
+				hash: MD5SaltedSHash,
+				salt: SaltEncoded,
+			},
+		},
+		{
+			name: "success prefix",
+			args: args{MD5SaltedEncodedP},
+			want: &checker{
+				hash: MD5SaltedPHash,
+				salt: SaltEncoded,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parse(tt.args.encoded)
+			if !tt.wantErr && got == nil && err == nil {
+				return
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != nil && tt.want != nil {
+				if got.salt != tt.want.salt || got.hash != tt.want.hash || got.saltpasswfunc == nil {
+					t.Errorf("parse() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func Test_checker_verify(t *testing.T) {
+	type args struct {
+		password string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    verifier.Result
+		encoded string
+	}{
+		{
+			name:    "success suffix",
+			args:    args{Password},
+			want:    verifier.OK,
+			encoded: MD5SaltedEncodedS,
+		},
+		{
+			name:    "success prefix",
+			args:    args{Password},
+			want:    verifier.OK,
+			encoded: MD5SaltedEncodedP,
+		},
+		{
+			name:    "wrong password suffix",
+			args:    args{"foobar"},
+			want:    verifier.Fail,
+			encoded: MD5SaltedEncodedS,
+		},
+		{
+			name:    "wrong password prefix",
+			args:    args{"foobar"},
+			want:    verifier.Fail,
+			encoded: MD5SaltedEncodedP,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, _ := parse(tt.encoded)
+			got, _ := parsed.verify(tt.args.password)
+			if got != tt.want {
+				t.Errorf("checker.verify() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVerify(t *testing.T) {
+	type args struct {
+		encoded  string
+		password string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    verifier.Result
+		wantErr bool
+	}{
+		{
+			name:    "decode error",
+			args:    args{"$md5salted$salt$foo", Password},
+			want:    verifier.Skip,
+			wantErr: true,
+		},
+		{
+			name: "wrong prefix",
+			args: args{testvalues.ScryptEncoded, Password},
+			want: verifier.Skip,
+		},
+		{
+			name: "wrong password suffix",
+			args: args{MD5SaltedEncodedS, "foobar"},
+			want: verifier.Fail,
+		},
+		{
+			name: "success suffix",
+			args: args{MD5SaltedEncodedS, Password},
+			want: verifier.OK,
+		},
+		{
+			name: "wrong password prefix",
+			args: args{MD5SaltedEncodedP, "foobar"},
+			want: verifier.Fail,
+		},
+		{
+			name: "success prefix",
+			args: args{MD5SaltedEncodedP, Password},
+			want: verifier.OK,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Verify(tt.args.encoded, tt.args.password)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Verify() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Verify() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/md5salted/md5salted_test.go
+++ b/md5salted/md5salted_test.go
@@ -42,7 +42,7 @@ func Test_parse(t *testing.T) {
 		},
 		{
 			name:    "wrong identifier",
-			args:    args{"$md5salted-unknow$foo$foo"},
+			args:    args{"$md5salted-unknown$foo$foo"},
 			wantErr: true,
 		},
 		{

--- a/md5salted/md5salted_test.go
+++ b/md5salted/md5salted_test.go
@@ -104,6 +104,12 @@ func Test_checker_verify(t *testing.T) {
 			encoded: MD5SaltedEncodedP,
 		},
 		{
+			name:    "hash decode error",
+			args:    args{Password},
+			want:    verifier.Skip,
+			encoded: "$md5salted-prefix$c2FsdA==$~~~~~~~",
+		},
+		{
 			name:    "wrong password suffix",
 			args:    args{"foobar"},
 			want:    verifier.Fail,


### PR DESCRIPTION
Allow salted passwords hashed with MD5 to be verified. Accept salt as prefix or as suffix of the password. Don't allow to use as hasher.

new feature