### PR TITLE
feat(crypto): Add sha2 (based on crypt(3)) hashing algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,22 +29,24 @@ needs to be updated.
 ### Algorithms
 
 | Algorithm       | Identifiers                                                        | Secure             |
-|-----------------|--------------------------------------------------------------------| ------------------ |
+| --------------- | ------------------------------------------------------------------ | ------------------ |
 | [argon2][1]     | argon2i, argon2id                                                  | :heavy_check_mark: |
 | [bcrypt][2]     | 2, 2a, 2b, 2y                                                      | :heavy_check_mark: |
 | [md5-crypt][3]  | 1                                                                  | :x:                |
 | [md5 plain][4]  | Hex encoded string                                                 | :x:                |
 | [md5 salted][5] | md5salted-suffix,md5salted-prefix                                  | :x:                |
-| [scrypt][6]     | scrypt, 7                                                          | :heavy_check_mark: |
-| [pbkpdf2][7]    | pbkdf2, pbkdf2-sha224, pbkdf2-sha256, pbkdf2-sha384, pbkdf2-sha512 | :heavy_check_mark: |
+| [sha2-crypt][6] | 5, 6                                                               | :heavy_check_mark: |
+| [scrypt][7]     | scrypt, 7                                                          | :heavy_check_mark: |
+| [pbkpdf2][8]    | pbkdf2, pbkdf2-sha224, pbkdf2-sha256, pbkdf2-sha384, pbkdf2-sha512 | :heavy_check_mark: |
 
 [1]: https://pkg.go.dev/github.com/zitadel/passwap/argon2
 [2]: https://pkg.go.dev/github.com/zitadel/passwap/bcrypt
 [3]: https://pkg.go.dev/github.com/zitadel/passwap/md5
 [4]: https://pkg.go.dev/github.com/zitadel/passwap/md5plain
 [5]: https://pkg.go.dev/github.com/zitadel/passwap/md5salted
-[6]: https://pkg.go.dev/github.com/zitadel/passwap/scrypt
-[7]: https://pkg.go.dev/github.com/zitadel/passwap/pbkdf2
+[6]: https://pkg.go.dev/github.com/zitadel/passwap/sha2
+[7]: https://pkg.go.dev/github.com/zitadel/passwap/scrypt
+[8]: https://pkg.go.dev/github.com/zitadel/passwap/pbkdf2
 
 ### Encoding
 
@@ -138,6 +140,21 @@ $md5salted-suffix$kJ4QkJaQ$3EbD/pJddrq5HW3mpZ4KZ1
 3. Base64-like-encoded MD5 hash output of the password and salt combined (password+salt or salt+password).
 
 There is no cost parameter for MD5 because MD5 is old and is considered too light and insecure. It is provided to verify and migrate to a better algorithm. Do not use for new hashes.
+
+### SHA2 crypt
+
+SHA2 Crypt shares its encoding scheme with MD5 Crypt, but uses SHA-256 or SHA-512 instead of MD5 and uses a different [hashing algorithm](https://www.akkadia.org/drepper/SHA-crypt.txt)
+The resulting Modular Crypt Format string looks as follows:
+
+```
+$5$rounds=5000$RPvilwjD1ebXJfzg$5B8vYYiY.CVt1RlTTf8KbXBH3hsxY/GNooZaBBGWEc5
+(1)   (2)           (3)                 (4)
+```
+
+1. The identifier is always `5` (SHA-256) or `6` (SHA-512)
+2. The cost parameter in rounds, which is a linear value - `5000` in this example. Note that according to the specification this part is optional (in which case the default of 5000 rounds will be used). In this implementation the rounds are always returned, even when they match the default
+3. Base64-like-encoded salt.
+4. Base64-like-encoded SHA-256/512 hash output of the password and salt combined.
 
 ### Scrypt
 

--- a/internal/encoding/crypt3.go
+++ b/internal/encoding/crypt3.go
@@ -1,0 +1,22 @@
+package encoding
+
+const encoding = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+// crypt(3) uses a slightly different Base64 scheme. Also called hash64 in PassLib
+func EncodeCrypt3(raw []byte) []byte {
+	dest := make([]byte, 0, (len(raw)*8+6-1)/6)
+
+	v := uint(0)
+	bits := uint(0)
+
+	for _, b := range raw {
+		v |= (uint(b) << bits)
+
+		for bits = bits + 8; bits > 6; bits -= 6 {
+			dest = append(dest, encoding[v&63])
+			v >>= 6
+		}
+	}
+	dest = append(dest, encoding[v&63])
+	return dest
+}

--- a/internal/encoding/crypt3.go
+++ b/internal/encoding/crypt3.go
@@ -1,7 +1,7 @@
 package encoding
 
 const encoding = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-
+const crypt3Encoding = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 // crypt(3) uses a slightly different Base64 scheme. Also called hash64 in PassLib
 func EncodeCrypt3(raw []byte) []byte {
 	dest := make([]byte, 0, (len(raw)*8+6-1)/6)
@@ -14,9 +14,9 @@ func EncodeCrypt3(raw []byte) []byte {
 
 		for bits = bits + 8; bits > 6; bits -= 6 {
 			dest = append(dest, encoding[v&63])
-			v >>= 6
+			dest = append(dest, crypt3Encoding[v&63])
 		}
 	}
 	dest = append(dest, encoding[v&63])
-	return dest
+	dest = append(dest, crypt3Encoding[v&63])
 }

--- a/internal/encoding/crypt3.go
+++ b/internal/encoding/crypt3.go
@@ -1,7 +1,7 @@
 package encoding
 
-const encoding = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 const crypt3Encoding = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
 // crypt(3) uses a slightly different Base64 scheme. Also called hash64 in PassLib
 func EncodeCrypt3(raw []byte) []byte {
 	dest := make([]byte, 0, (len(raw)*8+6-1)/6)
@@ -13,10 +13,10 @@ func EncodeCrypt3(raw []byte) []byte {
 		v |= (uint(b) << bits)
 
 		for bits = bits + 8; bits > 6; bits -= 6 {
-			dest = append(dest, encoding[v&63])
 			dest = append(dest, crypt3Encoding[v&63])
+			v >>= 6
 		}
 	}
-	dest = append(dest, encoding[v&63])
 	dest = append(dest, crypt3Encoding[v&63])
+	return dest
 }

--- a/internal/encoding/crypt3_test.go
+++ b/internal/encoding/crypt3_test.go
@@ -1,0 +1,49 @@
+package encoding
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEncodeCrypt3(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  []byte
+		want []byte
+	}{
+		{
+			name: "Empty input",
+			raw:  []byte{},
+			want: []byte{'.'},
+		},
+		{
+			name: "Single byte",
+			raw:  []byte{255},
+			want: []byte{'z', '1'},
+		},
+		{
+			name: "Two bytes",
+			raw:  []byte{255, 255},
+			want: []byte{'z', 'z', 'D'},
+		},
+		{
+			name: "Three bytes",
+			raw:  []byte{255, 255, 255},
+			want: []byte{'z', 'z', 'z', 'z'},
+		},
+		{
+			name: "Patterned input",
+			raw:  []byte{0, 1, 2, 3, 4, 5, 6, 7},
+			want: []byte{'.', '2', 'U', '.', '1', 'E', 'E', '/', '4', 'Q', '.'},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EncodeCrypt3(tt.raw)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("EncodeCrypt3() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/sha2/sha2.go
+++ b/sha2/sha2.go
@@ -1,0 +1,303 @@
+// Package sha2 provides hashing and verification of
+// SHA-256 and SHA-512 encoded passwords with salt based on crypt(3).
+// [The algorithm](https://www.akkadia.org/drepper/SHA-crypt.txt)
+// builds hashes through multiple digest iterations
+// with shuffles of password and salt.
+package sha2
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/subtle"
+	"fmt"
+	"hash"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/zitadel/passwap/internal/encoding"
+	"github.com/zitadel/passwap/internal/salt"
+	"github.com/zitadel/passwap/verifier"
+)
+
+const (
+	Sha256Identifier = "$5$"
+	Sha512Identifier = "$6$"
+	SaltLenMin       = 1
+	SaltLenMax       = 16
+	RoundsMin        = 1000
+	RoundsMax        = 999999999
+	RoundsDefault    = 5000
+)
+
+func createHash(is512 bool, password, salt []byte, rounds int) []byte {
+	if len(salt) > 16 {
+		salt = salt[0:16]
+	}
+
+	var hash hash.Hash
+	if is512 {
+		hash = sha512.New()
+	} else {
+		hash = sha256.New()
+	}
+	digest := createDigest(hash, password, salt, calcRounds(rounds))
+
+	return []byte(createOutputString(is512, digest, salt, calcRounds(rounds)))
+}
+
+func calcRounds(rounds int) int {
+	if rounds < RoundsMin {
+		return RoundsMin
+	}
+	if rounds > RoundsMax {
+		return RoundsMax
+	}
+	return rounds
+}
+
+// Follows the algorithm steps 1 - 21 outlined in https://www.akkadia.org/drepper/SHA-crypt.txt
+func createDigest(hash hash.Hash, password, salt []byte, rounds int) []byte {
+	// steps 4 - 6 (we start with digest B because it is more convenient)
+	hash.Write(password)
+	hash.Write(salt)
+	hash.Write(password)
+	digestB := hash.Sum(nil)
+
+	// steps 1 - 3
+	hash.Reset()
+	hash.Write(password)
+	hash.Write(salt)
+
+	// step 9 - 10
+	passwordLength := len(password)
+	hash.Write(repeatBytesToSize(digestB, passwordLength))
+
+	// step 11
+	for i := passwordLength; i != 0; i >>= 1 {
+		if i&1 == 1 {
+			hash.Write(digestB)
+		} else {
+			hash.Write(password)
+		}
+	}
+
+	// step 12
+	digestA := hash.Sum(nil)
+
+	// step 13 - 15
+	hash.Reset()
+	for i := 0; i < len(password); i++ {
+		hash.Write(password)
+	}
+	digestDP := hash.Sum(nil)
+
+	// step 16
+	sequenceP := repeatBytesToSize(digestDP, passwordLength)
+
+	// step 17 - 19
+	hash.Reset()
+	for i := 0; i < (16 + int(digestA[0])); i++ {
+		hash.Write(salt)
+	}
+	digestDS := hash.Sum(nil)
+
+	// step 20
+	sequenceS := repeatBytesToSize(digestDS, len(salt))
+
+	// step 21
+	digestC := digestA
+
+	for i := 0; i < rounds; i++ {
+		hash.Reset()
+		if i%2 != 0 { // step 21.b
+			hash.Write(sequenceP)
+		} else { // step 21.c
+			hash.Write(digestC)
+		}
+		if i%3 != 0 { // step 21.d
+			hash.Write(sequenceS)
+		}
+		if i%7 != 0 { // step 21.e
+			hash.Write(sequenceP)
+		}
+		if i%2 != 0 { // step 21.f
+			hash.Write(digestC)
+		} else { // step 21.g
+			hash.Write(sequenceP)
+		}
+		digestC = hash.Sum(nil)
+	}
+	return digestC
+}
+
+func createOutputString(is512 bool, digest, salt []byte, rounds int) string {
+	var builder strings.Builder
+
+	builder.WriteString("$")
+	if is512 {
+		builder.WriteString("6")
+	} else {
+		builder.WriteString("5")
+	}
+	builder.WriteString("$")
+	builder.WriteString(fmt.Sprintf("rounds=%d", rounds))
+	builder.WriteString("$")
+	builder.WriteString(string(salt))
+	builder.WriteString("$")
+
+	var transposed []byte
+	if is512 {
+		transposed = transpose(digest, transposeMap512)
+	} else {
+		transposed = transpose(digest, transposeMap256)
+	}
+	builder.WriteString(string(encoding.EncodeCrypt3(transposed)))
+	return builder.String()
+}
+
+func transpose(input []byte, transposeMap []int) []byte {
+	result := make([]byte, len(transposeMap))
+	for i, off := range transposeMap {
+		if off < len(input) {
+			result[i] = input[off]
+		}
+	}
+	return result
+}
+
+func repeatBytesToSize(input []byte, size int) []byte {
+	repeats := 1 + (size-1)/len(input)
+	return bytes.Repeat(input, repeats)[:size]
+}
+
+var (
+	transposeMap256 = []int{20, 10, 0, 11, 1, 21, 2, 22, 12, 23, 13, 3, 14, 4, 24, 5, 25, 15, 26, 16, 6, 17, 7, 27, 8, 28, 18, 29, 19, 9, 30, 31}
+
+	transposeMap512 = []int{
+		42, 21, 0, 1, 43, 22, 23, 2, 44, 45, 24, 3, 4, 46, 25, 26,
+		5, 47, 48, 27, 6, 7, 49, 28, 29, 8, 50, 51, 30, 9, 10, 52,
+		31, 32, 11, 53, 54, 33, 12, 13, 55, 34, 35, 14, 56, 57, 36, 15,
+		16, 58, 37, 38, 17, 59, 60, 39, 18, 19, 61, 40, 41, 20, 62, 63,
+	}
+)
+
+type checker struct {
+	use512 bool
+	rounds int
+	hash   []byte
+	salt   []byte
+}
+
+func parse(hash string) (*checker, error) {
+	parts := strings.Split(hash, "$")
+	if len(parts) < 4 {
+		return nil, fmt.Errorf("invalid format")
+	}
+
+	if parts[1] != "5" && parts[1] != "6" {
+		return nil, fmt.Errorf("invalid identifier")
+	}
+
+	var checker checker
+
+	checker.use512 = parts[1] == "6"
+
+	i := 2
+	if strings.HasPrefix(parts[2], "rounds=") {
+		rounds, err := strconv.Atoi(strings.TrimPrefix(parts[2], "rounds="))
+		if err != nil {
+			return nil, fmt.Errorf("invalid rounds value")
+		}
+		checker.rounds = rounds
+		i++
+	} else {
+		checker.rounds = RoundsDefault
+	}
+
+	if i+1 >= len(parts) {
+		return nil, fmt.Errorf("invalid format")
+	}
+
+	checker.salt = []byte(parts[i])
+	checker.hash = []byte(hash)
+	return &checker, nil
+}
+
+func (c *checker) verify(password string) verifier.Result {
+	passwordHash := createHash(c.use512, []byte(password), c.salt, c.rounds)
+	fmt.Printf("Debug: rounds=%v\n", string(passwordHash))
+	res := subtle.ConstantTimeCompare(passwordHash, c.hash)
+
+	return verifier.Result(res)
+}
+
+// Hasher hashes and verifies crypt(3) style SHA256 and SHA512 passwords.
+type Hasher struct {
+	use512 bool
+	rounds int
+	rand   io.Reader
+}
+
+// Hash implements passwap.Hasher.
+func (h *Hasher) Hash(password string) (string, error) {
+	salt, err := salt.New(h.rand, 16)
+	fmt.Printf("Debug: rounds=%v\n", string(salt))
+	if err != nil {
+		return "", fmt.Errorf("sha2: %w", err)
+	}
+
+	encoded := createHash(h.use512, []byte(password), salt, h.rounds)
+
+	return string(encoded), nil
+}
+
+// Verify implements passwap.Verifier
+func (h *Hasher) Verify(encoded, password string) (verifier.Result, error) {
+	c, err := parse(encoded)
+	if err != nil || c == nil {
+		return verifier.Skip, err
+	}
+
+	res := c.verify(password)
+	if res == 0 {
+		return verifier.Fail, err
+	}
+
+	if h.rounds != c.rounds {
+		return verifier.NeedUpdate, nil
+	}
+
+	return verifier.OK, nil
+}
+
+func New256(rounds int) *Hasher {
+	return &Hasher{
+		use512: false,
+		rounds: rounds,
+		rand:   rand.Reader,
+	}
+}
+func New512(rounds int) *Hasher {
+	return &Hasher{
+		use512: true,
+		rounds: rounds,
+		rand:   rand.Reader,
+	}
+}
+
+// Verify parses encoded and uses its parameters
+// to verify password against its hash.
+func Verify(encoded, password string) (verifier.Result, error) {
+	c, err := parse(encoded)
+	if err != nil || c == nil {
+		return verifier.Skip, err
+	}
+
+	return c.verify(password), nil
+}
+
+// Verifier for sha2.
+var Verifier = verifier.VerifyFunc(Verify)

--- a/sha2/sha2.go
+++ b/sha2/sha2.go
@@ -228,7 +228,6 @@ func parse(hash string) (*checker, error) {
 
 func (c *checker) verify(password string) verifier.Result {
 	passwordHash := createHash(c.use512, []byte(password), c.salt, c.rounds)
-	fmt.Printf("Debug: rounds=%v\n", string(passwordHash))
 	res := subtle.ConstantTimeCompare(passwordHash, c.hash)
 
 	return verifier.Result(res)
@@ -244,12 +243,12 @@ type Hasher struct {
 // Hash implements passwap.Hasher.
 func (h *Hasher) Hash(password string) (string, error) {
 	salt, err := salt.New(h.rand, 16)
-	fmt.Printf("Debug: rounds=%v\n", string(salt))
 	if err != nil {
 		return "", fmt.Errorf("sha2: %w", err)
 	}
 
-	encoded := createHash(h.use512, []byte(password), salt, h.rounds)
+	encSalt := encoding.EncodeCrypt3(salt)
+	encoded := createHash(h.use512, []byte(password), encSalt, h.rounds)
 
 	return string(encoded), nil
 }

--- a/sha2/sha2.go
+++ b/sha2/sha2.go
@@ -193,7 +193,8 @@ type checker struct {
 
 func parse(hash string) (*checker, error) {
 	parts := strings.Split(hash, "$")
-	if len(parts) < 4 {
+	partsLen := len(parts) - 1
+	if partsLen < 3 || partsLen > 4 {
 		return nil, fmt.Errorf("invalid format")
 	}
 
@@ -215,10 +216,6 @@ func parse(hash string) (*checker, error) {
 		i++
 	} else {
 		checker.rounds = RoundsDefault
-	}
-
-	if i+1 >= len(parts) {
-		return nil, fmt.Errorf("invalid format")
 	}
 
 	checker.salt = []byte(parts[i])

--- a/sha2/sha2_test.go
+++ b/sha2/sha2_test.go
@@ -227,7 +227,7 @@ func TestHasher_Hash(t *testing.T) {
 		{
 			name: "succes",
 			rand: strings.NewReader("saltsaltsaltsalt"),
-			want: "$6$rounds=10000$saltsaltsaltsalt$EZKkFhxaTyiAhcKpFxN09.libqbOVLez7TJLU9i1rGqmCJkU4O5MLKPlNmVFwvj9YM3HTmo.EQeTrTAI01tZz1",
+			want: "$6$rounds=10000$n34PoBLMgFrQVl4R$7.cb7CLz8wagvy7HkLZ8dcil04pgps4hbri2LxtxwEUvf82JeV07F65sPWlHuwPBoVO6q49Az1vHmyvfmxw6Z/",
 		},
 	}
 

--- a/sha2/sha2_test.go
+++ b/sha2/sha2_test.go
@@ -1,0 +1,389 @@
+package sha2
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/zitadel/passwap/internal/salt"
+	"github.com/zitadel/passwap/verifier"
+)
+
+// test cases taken from https://www.akkadia.org/drepper/SHA-crypt.txt
+func Test_createHash512(t *testing.T) {
+	type args struct {
+		password string
+		salt     string
+		rounds   int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "basic",
+			args: args{"Hello world!", "saltstring", 5000},
+			want: "$6$rounds=5000$saltstring$svn8UoSVapNtMuq1ukKS4tPQd8iKwSMHWjl/O817G3uBnIFNjnQJuesI68u4OTLiBFdcbYEdFCoEOfaS35inz1",
+		},
+		{
+			name: "10000 rounds and long salt",
+			args: args{"Hello world!", "saltstringsaltstring", 10000},
+			want: "$6$rounds=10000$saltstringsaltst$OW1/O6BYHV6BcXZu8QVeXbDWra3Oeqh0sbHbbMCVNSnCM/UrjmM0Dp8vOuZeHBy/YTBmSK6H9qs/y3RnOaw5v.",
+		},
+		{
+			name: "long salt",
+			args: args{"This is just a test", "toolongsaltstring", 5000},
+			want: "$6$rounds=5000$toolongsaltstrin$lQ8jolhgVRVhY4b5pZKaysCLi0QBxGoNeKQzQ3glMhwllF7oGDZxUhx1yxdYcz/e1JSbq3y6JMxxl8audkUEm0",
+		},
+		{
+			name: "long password and long salt",
+			args: args{"a very much longer text to encrypt.  This one even stretches over morethan one line.", "anotherlongsaltstring", 1400},
+			want: "$6$rounds=1400$anotherlongsalts$POfYwTEok97VWcjxIiSOjiykti.o/pQs.wPvMxQ6Fm7I6IoYN3CmLs66x9t0oSwbtEW7o7UmJEiDwGqd8p4ur1",
+		},
+		{
+			name: "short salt",
+			args: args{"we have a short salt string but not a short password", "short", 77777},
+			want: "$6$rounds=77777$short$WuQyW2YR.hBNpjjRhpYD/ifIw05xdfeEyQoMxIXbkvr0gge1a1x3yRULJ5CCaUeOxFmtlcGZelFl5CxtgfiAc0",
+		},
+		{
+			name: "short password",
+			args: args{"a short string", "asaltof16chars..", 123456},
+			want: "$6$rounds=123456$asaltof16chars..$BtCwjqMJGx5hrJhZywWvt0RLE8uZ4oPwcelCjmw2kSYu.Ec6ycULevoBK25fs2xXgMNrCzIMVcgEJAstJeonj1",
+		},
+		{
+			name: "low rounds",
+			args: args{"the minimum number is still observed", "roundstoolow", 10},
+			want: "$6$rounds=1000$roundstoolow$kUMsbe306n21p9R.FRkW3IGn.S9NPN0x50YhH1xhLsPuWGsUSklZt58jaTfF4ZEQpyUNGc0dqbpBYYBaHHrsX.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash := createHash(true, []byte(tt.args.password), []byte(tt.args.salt), tt.args.rounds)
+			if !bytes.Equal(hash, []byte(tt.want)) {
+				t.Errorf("createHash() = %v, want %v", string(hash), (tt.want))
+			}
+		})
+	}
+}
+
+// test cases taken from https://www.akkadia.org/drepper/SHA-crypt.txt
+func Test_createHash256(t *testing.T) {
+	type args struct {
+		password string
+		salt     string
+		rounds   int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "basic",
+			args: args{"Hello world!", "saltstring", 5000},
+			want: "$5$rounds=5000$saltstring$5B8vYYiY.CVt1RlTTf8KbXBH3hsxY/GNooZaBBGWEc5",
+		},
+		{
+			name: "10000 rounds and long salt",
+			args: args{"Hello world!", "saltstringsaltstring", 10000},
+			want: "$5$rounds=10000$saltstringsaltst$3xv.VbSHBb41AL9AvLeujZkZRBAwqFMz2.opqey6IcA",
+		},
+		{
+			name: "long salt",
+			args: args{"This is just a test", "toolongsaltstring", 5000},
+			want: "$5$rounds=5000$toolongsaltstrin$Un/5jzAHMgOGZ5.mWJpuVolil07guHPvOW8mGRcvxa5",
+		},
+		{
+			name: "long password and long salt",
+			args: args{"a very much longer text to encrypt.  This one even stretches over morethan one line.", "anotherlongsaltstring", 1400},
+			want: "$5$rounds=1400$anotherlongsalts$Rx.j8H.h8HjEDGomFU8bDkXm3XIUnzyxf12oP84Bnq1",
+		},
+		{
+			name: "short salt",
+			args: args{"we have a short salt string but not a short password", "short", 77777},
+			want: "$5$rounds=77777$short$JiO1O3ZpDAxGJeaDIuqCoEFysAe1mZNJRs3pw0KQRd/",
+		},
+		{
+			name: "short password",
+			args: args{"a short string", "asaltof16chars..", 123456},
+			want: "$5$rounds=123456$asaltof16chars..$gP3VQ/6X7UUEW3HkBn2w1/Ptq2jxPyzV/cZKmF/wJvD",
+		},
+		{
+			name: "low rounds",
+			args: args{"the minimum number is still observed", "roundstoolow", 10},
+			want: "$5$rounds=1000$roundstoolow$yfvwcWrQ8l/K0DAWyuPMDNHpIVlTQebY9l/gL972bIC",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash := createHash(false, []byte(tt.args.password), []byte(tt.args.salt), tt.args.rounds)
+			if !bytes.Equal(hash, []byte(tt.want)) {
+				t.Errorf("createHash() = %v, want %v", string(hash), (tt.want))
+			}
+		})
+	}
+}
+
+func Test_parse(t *testing.T) {
+	tests := []struct {
+		input   string
+		use512  bool
+		rounds  int
+		salt    string
+		encoded string
+		wantErr bool
+	}{
+		{"$6$rounds=10000$somesalt$hashvaluehere", true, 10000, "somesalt", "hashvaluehere", false},
+		{"$5$saltvalue$hasheddata", false, RoundsDefault, "saltvalue", "hasheddata", false},
+		{"$6$salt$encodedhash", true, RoundsDefault, "salt", "encodedhash", false},
+		{"$5$rounds=20000$salt$hash", false, 20000, "salt", "hash", false},
+		{"$2$rounds=10000$somesalt$hashvaluehere", false, RoundsDefault, "", "", true}, // Invalid identiefier
+		{"$6$rounds=abc$salt$hash", false, RoundsDefault, "", "", true},                // Invalid rounds
+		{"$6$salt", false, RoundsDefault, "", "", true},                                // Missing encoded part
+		{"invalidhash", false, RoundsDefault, "", "", true},                            // Completely invalid format
+	}
+
+	for _, tt := range tests {
+		c, err := parse(tt.input)
+
+		if (err != nil) != tt.wantErr {
+			t.Errorf("parse() error = %v, wantErr %v", err, tt.wantErr)
+			return
+		}
+
+		if c != nil {
+			if c.use512 != tt.use512 {
+				t.Errorf("parseHash(%q) use512 = %v, want %v", tt.input, c.use512, tt.use512)
+			}
+
+			if c.rounds != tt.rounds {
+				t.Errorf("parseHash(%q) rounds = %v, want %v", tt.input, c.rounds, tt.rounds)
+			}
+
+			if string(c.salt) != tt.salt {
+				t.Errorf("parseHash(%q) salt = %q, want %q", tt.input, c.salt, tt.salt)
+			}
+
+			if string(c.hash) != tt.input {
+				t.Errorf("parseHash(%q) encoded = %q, want %q", tt.input, c.hash, tt.input)
+			}
+		}
+	}
+}
+
+func Test_checker_verify(t *testing.T) {
+	tests := []struct {
+		name     string
+		password string
+		want     verifier.Result
+		wantErr  bool
+	}{
+		{
+			name:     "wrong password",
+			password: "foo",
+			want:     verifier.Fail,
+		},
+		{
+			name:     "correct password",
+			password: "password",
+			want:     verifier.OK,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := &checker{
+				use512: true,
+				rounds: 5000,
+				hash:   []byte("$6$rounds=5000$salt$IxDD3jeSOb5eB1CX5LBsqZFVkJdido3OUILO5Ifz5iwMuTS4XMS130MTSuDDl3aCI6WouIL9AjRbLCelDCy.g."),
+				salt:   []byte("salt"),
+			}
+
+			if got := checker.verify(tt.password); got != tt.want {
+				t.Errorf("checker.verify() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasher_Hash(t *testing.T) {
+	tests := []struct {
+		name    string
+		rand    io.Reader
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "salt error",
+			rand:    salt.ErrReader{},
+			wantErr: true,
+		},
+		{
+			name: "succes",
+			rand: strings.NewReader("saltsaltsaltsalt"),
+			want: "$6$rounds=10000$saltsaltsaltsalt$EZKkFhxaTyiAhcKpFxN09.libqbOVLez7TJLU9i1rGqmCJkU4O5MLKPlNmVFwvj9YM3HTmo.EQeTrTAI01tZz1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Hasher{
+				use512: true,
+				rounds: 10000,
+				rand:   tt.rand,
+			}
+
+			got, err := h.Hash("foobar")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Hasher.Hash() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Hasher.Hash() =\n%v\nwant\n%v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasher_Verify(t *testing.T) {
+	password := "foobar"
+	encoded := "$6$rounds=10000$saltsaltsaltsalt$EZKkFhxaTyiAhcKpFxN09.libqbOVLez7TJLU9i1rGqmCJkU4O5MLKPlNmVFwvj9YM3HTmo.EQeTrTAI01tZz1"
+	tests := []struct {
+		name     string
+		rounds   int
+		encoded  string
+		password string
+		want     verifier.Result
+		wantErr  bool
+	}{
+		{
+			name:     "parse error",
+			encoded:  "totallywrongformat",
+			password: password,
+			rounds:   10000,
+			want:     verifier.Skip,
+			wantErr:  true,
+		},
+		{
+			name:     "wrong password",
+			encoded:  encoded,
+			password: "wrong",
+			rounds:   10000,
+			want:     verifier.Fail,
+		},
+		{
+			name:     "need update",
+			encoded:  encoded,
+			password: password,
+			rounds:   2000,
+			want:     verifier.NeedUpdate,
+		},
+		{
+			name:     "succes",
+			encoded:  encoded,
+			password: password,
+			rounds:   10000,
+			want:     verifier.OK,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Hasher{
+				use512: true,
+				rounds: tt.rounds,
+				rand:   strings.NewReader("saltsaltsaltsalt"),
+			}
+			got, err := h.Verify(tt.encoded, tt.password)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Hasher.Verify() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Hasher.Verify() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasher512(t *testing.T) {
+	h := New512(5000)
+	hash, err := h.Hash("password")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := h.Verify(hash, "password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != verifier.OK {
+		t.Errorf("Hasher.Verify() = %s, want %s", res, verifier.OK)
+	}
+}
+
+func TestHasher256(t *testing.T) {
+	h := New256(5000)
+	hash, err := h.Hash("password")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := h.Verify(hash, "password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != verifier.OK {
+		t.Errorf("Hasher.Verify() = %s, want %s", res, verifier.OK)
+	}
+}
+
+func TestVerify(t *testing.T) {
+	password := "foobar"
+	encoded := "$6$rounds=10000$saltsaltsaltsalt$EZKkFhxaTyiAhcKpFxN09.libqbOVLez7TJLU9i1rGqmCJkU4O5MLKPlNmVFwvj9YM3HTmo.EQeTrTAI01tZz1"
+
+	tests := []struct {
+		name     string
+		encoded  string
+		password string
+		want     verifier.Result
+		wantErr  bool
+	}{
+		{
+			name:     "parse error",
+			encoded:  "totallywrongformat",
+			password: password,
+			want:     verifier.Skip,
+			wantErr:  true,
+		},
+		{
+			name:     "wrong password",
+			encoded:  encoded,
+			password: "wrong",
+			want:     verifier.Fail,
+		},
+		{
+			name:     "success",
+			encoded:  encoded,
+			password: password,
+			want:     verifier.OK,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Verify(tt.encoded, tt.password)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Verify() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Verify() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds crypt(3) style hashing and verifying for SHA-256 and SHA-512. Based on the information from passlib and https://www.akkadia.org/drepper/SHA-crypt.txt