### PR TITLE
feat(crypto): Add PHPass hashing algorithm (verifier only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,20 @@ needs to be updated.
 | [md5-crypt][3]  | 1                                                                  | :x:                |
 | [md5 plain][4]  | Hex encoded string                                                 | :x:                |
 | [md5 salted][5] | md5salted-suffix,md5salted-prefix                                  | :x:                |
-| [sha2-crypt][6] | 5, 6                                                               | :heavy_check_mark: |
-| [scrypt][7]     | scrypt, 7                                                          | :heavy_check_mark: |
-| [pbkpdf2][8]    | pbkdf2, pbkdf2-sha224, pbkdf2-sha256, pbkdf2-sha384, pbkdf2-sha512 | :heavy_check_mark: |
+| [phpass][6]     | P, H                                                               | :x:                |
+| [sha2-crypt][7] | 5, 6                                                               | :heavy_check_mark: |
+| [scrypt][8]     | scrypt, 7                                                          | :heavy_check_mark: |
+| [pbkpdf2][9]    | pbkdf2, pbkdf2-sha224, pbkdf2-sha256, pbkdf2-sha384, pbkdf2-sha512 | :heavy_check_mark: |
 
 [1]: https://pkg.go.dev/github.com/zitadel/passwap/argon2
 [2]: https://pkg.go.dev/github.com/zitadel/passwap/bcrypt
 [3]: https://pkg.go.dev/github.com/zitadel/passwap/md5
 [4]: https://pkg.go.dev/github.com/zitadel/passwap/md5plain
 [5]: https://pkg.go.dev/github.com/zitadel/passwap/md5salted
-[6]: https://pkg.go.dev/github.com/zitadel/passwap/sha2
-[7]: https://pkg.go.dev/github.com/zitadel/passwap/scrypt
-[8]: https://pkg.go.dev/github.com/zitadel/passwap/pbkdf2
+[5]: https://pkg.go.dev/github.com/zitadel/passwap/phpass
+[7]: https://pkg.go.dev/github.com/zitadel/passwap/sha2
+[8]: https://pkg.go.dev/github.com/zitadel/passwap/scrypt
+[9]: https://pkg.go.dev/github.com/zitadel/passwap/pbkdf2
 
 ### Encoding
 
@@ -140,6 +142,23 @@ $md5salted-suffix$kJ4QkJaQ$3EbD/pJddrq5HW3mpZ4KZ1
 3. Base64-like-encoded MD5 hash output of the password and salt combined (password+salt or salt+password).
 
 There is no cost parameter for MD5 because MD5 is old and is considered too light and insecure. It is provided to verify and migrate to a better algorithm. Do not use for new hashes.
+
+### PHPass
+
+[PHPass](https://passlib.readthedocs.io/en/stable/lib/passlib.hash.phpass.html?highlight=php#passlib.hash.phpass) is an algorithm used primarily in PHP application (e.g. WordPress).
+The resulting Modular Crypt Format string looks as follows:
+
+```
+$P$8ohUJ.1sdFw09/bMaAQPTGDNi2BIUt1
+(1)(2)  (3)       (4)
+```
+
+1. The identifier is `P`, except for phpBB3 databases, which use `H`
+2. The rounds as a single character
+3. Salt with a length of 8 characters
+4. Base64-like-encoded MDF hash output
+
+This algorithm is old and is considered too light and insecure. It is provided to verify and migrate to a better algorithm. Do not use for new hashes.
 
 ### SHA2 crypt
 

--- a/internal/encoding/crypt3.go
+++ b/internal/encoding/crypt3.go
@@ -1,5 +1,7 @@
 package encoding
 
+import "strings"
+
 const crypt3Encoding = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 // crypt(3) uses a slightly different Base64 scheme. Also called hash64 in PassLib
@@ -19,4 +21,12 @@ func EncodeCrypt3(raw []byte) []byte {
 	}
 	dest = append(dest, crypt3Encoding[v&63])
 	return dest
+}
+
+func DecodeInt6(b byte) int {
+	return strings.IndexByte(crypt3Encoding, b)
+}
+
+func EncodeInt6(val int) byte {
+	return crypt3Encoding[val]
 }

--- a/internal/encoding/crypt3_test.go
+++ b/internal/encoding/crypt3_test.go
@@ -47,3 +47,47 @@ func TestEncodeCrypt3(t *testing.T) {
 		})
 	}
 }
+
+func TestDecodeInt6(t *testing.T) {
+	tests := []struct {
+		input byte
+		want  int
+	}{
+		{'A', 12},
+		{'z', 63},
+		{'0', 2},
+		{'.', 0},
+		{'/', 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.input), func(t *testing.T) {
+			got := DecodeInt6(tc.input)
+			if got != tc.want {
+				t.Errorf("DecodeInt6(%q) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEncodeInt6(t *testing.T) {
+	tests := []struct {
+		input int
+		want  byte
+	}{
+		{12, 'A'},
+		{63, 'z'},
+		{2, '0'},
+		{0, '.'},
+		{1, '/'},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.want), func(t *testing.T) {
+			got := EncodeInt6(tc.input)
+			if got != tc.want {
+				t.Errorf("EncodeInt6(%d) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/phpass/phpass.go
+++ b/phpass/phpass.go
@@ -1,0 +1,71 @@
+// Package phpass provides verification of
+// passwords hashed using the PHPass algorithm.
+//
+// Note that PHPass is based on MD5 and is considered weak by modern standards.
+// This package is only provided for legacy applications
+// that wish to migrate away from PHPass to newer hashing methods.
+package phpass
+
+import (
+	"crypto/md5"
+	"crypto/subtle"
+	"errors"
+	"strings"
+
+	"github.com/zitadel/passwap/internal/encoding"
+	"github.com/zitadel/passwap/verifier"
+)
+
+const (
+	IdentifierP = "$P$"
+	IdentifierH = "$H$"
+
+	Format = "%s$%s"
+)
+
+// Verify checks if the given password matches the provided PHPass hash.
+func Verify(hash, password string) (verifier.Result, error) {
+	var identifier string
+
+	if strings.HasPrefix(hash, IdentifierP) {
+		identifier = IdentifierP
+	} else if strings.HasPrefix(hash, IdentifierH) {
+		identifier = IdentifierH
+	} else {
+		return verifier.Skip, errors.New("invalid identifier")
+	}
+
+	if len(hash) < 34 {
+		return verifier.Skip, errors.New("invalid phpass hash length")
+	}
+
+	// Extract rounds and salt
+	rounds := encoding.DecodeInt6(hash[3])
+	if rounds < 7 || rounds > 31 {
+		return verifier.Skip, errors.New("invalid rounds factor")
+	}
+	salt := hash[4:12]
+
+	res := crypt(password, salt, rounds, identifier)
+
+	match := subtle.ConstantTimeCompare([]byte(res), []byte(hash))
+
+	return verifier.Result(match), nil
+}
+
+func crypt(password, salt string, rounds int, identifier string) string {
+	hash := md5.New()
+	hash.Write([]byte(salt + password))
+
+	digest := hash.Sum(nil)
+	for i := 0; i < 1<<uint(rounds); i++ {
+		hash.Reset()
+		hash.Write(digest)
+		hash.Write([]byte(password))
+		digest = hash.Sum(nil)
+	}
+
+	return identifier + string(encoding.EncodeInt6(rounds)) + salt + string(encoding.EncodeCrypt3(digest[:16]))
+}
+
+var Verifier = verifier.VerifyFunc(Verify)

--- a/phpass/phpass_test.go
+++ b/phpass/phpass_test.go
@@ -1,0 +1,84 @@
+package phpass
+
+import (
+	"testing"
+
+	"github.com/zitadel/passwap/verifier"
+)
+
+//test cases taken from passlib
+
+func TestVerify(t *testing.T) {
+	tests := []struct {
+		password string
+		hash     string
+	}{
+		{"test12345", "$P$9IQRaTwmfeRo7ud9Fh4E2PdI0S3r.L0"},
+		{"test1", "$H$9aaaaaSXBjgypwqm.JsMssPLiS8YQ00"},
+		{"123456", "$H$9PE8jEklgZhgLmZl5.HYJAzfGCQtzi1"},
+		{"123456", "$H$9pdx7dbOW3Nnt32sikrjAxYFjX8XoK1"},
+		{"thisisalongertestPW", "$P$912345678LIjjb6PhecupozNBmDndU0"},
+		{"JohnRipper", "$P$612345678si5M0DDyPpmRCmcltU/YW/"},
+		{"JohnRipper", "$H$712345678WhEyvy1YWzT4647jzeOmo0"},
+		{"JohnRipper", "$P$B12345678L6Lpt4BxNotVIMILOa9u81"},
+		{"", "$P$7JaFQsPzJSuenezefD/3jHgt5hVfNH0"},
+		{"compL3X!", "$P$FiS0N5L672xzQx1rt1vgdJQRYKnQM9/"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.password, func(t *testing.T) {
+			result, err := Verify(tc.hash, tc.password)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if result != verifier.OK {
+				t.Errorf("password verification failed for hash: %s", tc.hash)
+			}
+		})
+	}
+}
+
+func TestVerifyMalformedHashes(t *testing.T) {
+	test := []string{
+		"$P$712345678",                       // Too short
+		"$X$912345678WhEyvy1YWzT4647jzeOmo0", // Invalid prefix
+		"$P$1IQRaTwmfeRo7ud9Fh4E2PdI0S3r.L0", // Rounds too low
+		"$P$cIQRaTwmfeRo7ud9Fh4E2PdI0S3r.L0", // Rounds too hight
+		"$P$912345678X@badSalt",              // Invalid salt chars
+	}
+
+	for _, hash := range test {
+		t.Run(hash, func(t *testing.T) {
+			result, err := Verify(hash, "irrelevant")
+			if err == nil {
+				t.Errorf("expected error for malformed hash: %s", hash)
+			}
+			if result != verifier.Skip {
+				t.Errorf("expected Skip for malformed hash: %s, got %v", hash, result)
+			}
+		})
+	}
+}
+
+func TestVerifyIncorrectPassword(t *testing.T) {
+	incorrectTests := []struct {
+		password string
+		hash     string
+	}{
+		{"wrongpassword", "$P$9IQRaTwmfeRo7ud9Fh4E2PdI0S3r.L0"},
+		{"12345", "$H$9PE8jEklgZhgLmZl5.HYJAzfGCQtzi1"},
+		{"notJohnRipper", "$P$612345678si5M0DDyPpmRCmcltU/YW/"},
+	}
+
+	for _, tc := range incorrectTests {
+		t.Run(tc.password, func(t *testing.T) {
+			result, err := Verify(tc.hash, tc.password)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if result != verifier.Fail {
+				t.Errorf("expected Failure for incorrect password, got %v", result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds verifier for PHPass algorithm (used in WordPress). Based on information from https://passlib.readthedocs.io/en/stable/lib/passlib.hash.phpass.html?highlight=php#passlib.hash.phpass

If/when accepted I also have a PR ready for the main Zitadel application which integrates with the changes in #59 and this PR.